### PR TITLE
Remove parent tag <testsuites> from junit.xml

### DIFF
--- a/bin/test-ocs.sh
+++ b/bin/test-ocs.sh
@@ -69,3 +69,5 @@ run-ci -m acceptance \
   --ocsci-conf "$CLUSTER_CONFIG" \
   --junit-xml "$JUNIT_XML"
 
+# Remove testsuites tag from junit xml
+sed -i 's/<testsuites>\|<\/testsuites>//g' $JUNIT_XML


### PR DESCRIPTION
This fixes the unmarshaling error of junit.xml in osde2e
Signed-off-by: kesavan <kvellalo@redhat.com>